### PR TITLE
Add deep-copy and extend

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ var safeCloneDeep = require('safe-clone-deep')
 var structuredClone = require('structured-clone')
 var utilsCopy = require('utils-copy')
 var v8clone = require('node-v8-clone').clone
+var dcopy = require('deep-copy')
+var extend = require('extend')
 
 var suite = new Benchmark.Suite()
 
@@ -66,6 +68,14 @@ suite.add('JSON.stringify', function () {
 
 .add('node-v8-clone', function () {
   v8clone(fixture, true)
+})
+
+.add('deep-copy', function () {
+  dcopy(fixture)
+})
+
+.add('extend', function () {
+  extend(true, {}, fixture)
 })
 
 // add listeners

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "node-v8-clone": "0.6.2",
     "safe-clone-deep": "1.0.5",
     "structured-clone": "0.2.2",
-    "utils-copy": "1.0.0"
+    "utils-copy": "1.0.0",
+    "deep-copy": "1.0.0",
+    "extend": "2.0.1"
   }
 }


### PR DESCRIPTION
Added two more ways of deep copying. The first one is my own module that turned out to be fairly slow :) the other one is a relatively popular module for extending objects.

The results I'm seeing are

```
  14 tests completed.

  JSON.stringify   x 17,458 ops/sec ±9.92% (60 runs sampled)
  clone            x  5,891 ops/sec ±5.06% (53 runs sampled)
  clone-deep       x 11,170 ops/sec ±10.09% (54 runs sampled)
  clone-extend     x  2,350 ops/sec ±4.97% (57 runs sampled)
  cloneextend      x  6,948 ops/sec ±7.82% (46 runs sampled)
  component-clone  x  7,515 ops/sec ±8.03% (58 runs sampled)
  deepcopy         x  6,452 ops/sec ±9.56% (54 runs sampled)
  lodash           x 11,086 ops/sec ±9.35% (52 runs sampled)
  safe-clone-deep  x 10,457 ops/sec ±8.70% (59 runs sampled)
  structured-clone x  9,434 ops/sec ±8.82% (53 runs sampled)
  utils-copy       x  5,981 ops/sec ±11.98% (45 runs sampled)
  node-v8-clone    x 22,880 ops/sec ±10.46% (57 runs sampled)
  deep-copy        x  9,101 ops/sec ±8.82% (46 runs sampled)
  extend           x  7,490 ops/sec ±9.12% (49 runs sampled)

Fastest is node-v8-clone
Slowest is clone-extend
```

I think it would be good to sort the results in descending order before printing them. I didn't changed the readme, so these two modules are not added there.
